### PR TITLE
Add reporterOutput to jshint options

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -54,7 +54,8 @@ module.exports = function(grunt) {
         browser: true,{% } %}
         globals: {{% if (jquery) { %}
           jQuery: true
-        {% } %}}
+        {% } %}},
+        reporterOutput: ""
       },
       gruntfile: {
         src: 'Gruntfile.js'


### PR DESCRIPTION
After doing `npm install` I ran grunt and got this error:

```
Running "jshint:gruntfile" (jshint) task
Warning: Path must be a string. Received null Use --force to continue.
```

I found a solution that seems to work at https://github.com/jshint/jshint/issues/2922.
